### PR TITLE
Add .travis.yml to use Travis CI for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: 'ruby'
+rvm:
+  - '2.3'
+  - '2.4'
+  - '2.5'
+env:
+  global:
+    - 'SPEC_OPTS="--format doc"'
+notifications:
+  on_success: 'change'
+  on_failure: 'change'
+  on_start: false


### PR DESCRIPTION
自動でテストを走らせたりデプロイしたりできるようにするため、.travis.yml を追加して Travis CI を使います。